### PR TITLE
Fix Event::PRIO_NORMAL call in Watcher.pm

### DIFF
--- a/lib/Event/Watcher.pm
+++ b/lib/Event/Watcher.pm
@@ -52,7 +52,7 @@ sub init {
     # set up prio
     {
 	no strict 'refs';
-	$o->prio($ { ref($o)."::DefaultPriority" } || Event::PRIO_NORMAL);
+	$o->prio($ { ref($o)."::DefaultPriority" } || Event::PRIO_NORMAL());
 	if (exists $arg->{nice}) {
 	    $o->prio($o->prio + delete $arg->{nice});
 	}


### PR DESCRIPTION
I installed a cpan-Event Debian package that I am updating with last release (1.24). I ran the command bellow in a clean Debian chroot:

$ /usr/bin/perl -wc /usr/lib/x86_64-linux-gnu/perl5/5.20/Event/Watcher.pm

and got this error:

Bareword "Event::PRIO_NORMAL" not allowed while "strict subs" in use at /usr/src/tmp/perl-Event-buildroot/usr/lib/perl5/vendor_perl/ppc-linux/Event/Watcher.pm line 55.

Just adding the parenthesis in Event::PRIO_NORMAL call fix it. As was done in lib/Event/signal.pm line 6 with high priority::

$DefaultPriority = Event::PRIO_HIGH();

Thanks.
